### PR TITLE
Bump fo-dicom to 4.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+-   Bump fo-dicom from 4.0.6 to 4.0.7
+
 ## [2.3.1] - 2020-08-17
 
 - Add support for DX (Digital Radiography) modality

--- a/DicomTypeTranslation.Tests/DicomTypeTranslation.Tests.csproj
+++ b/DicomTypeTranslation.Tests/DicomTypeTranslation.Tests.csproj
@@ -65,7 +65,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="fo-dicom.Json" Version="4.0.6" />
+    <PackageReference Include="fo-dicom.Json" Version="4.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DicomTypeTranslation.Tests/JsonDicomConverterTests.cs
+++ b/DicomTypeTranslation.Tests/JsonDicomConverterTests.cs
@@ -1,8 +1,4 @@
 
-using System;
-using System.IO;
-using System.Linq;
-using System.Text;
 using Dicom;
 using Dicom.Serialization;
 using DicomTypeTranslation.Converters;
@@ -12,6 +8,10 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NLog;
 using NUnit.Framework;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
 
 namespace DicomTypeTranslation.Tests
 {
@@ -54,6 +54,11 @@ namespace DicomTypeTranslation.Tests
         public void SetUp()
         {
             TestLogger.Setup();
+
+            // NOTE(rkm 2020-11-02) Disable so we can create DicomDatasets with specific test values
+#pragma warning disable 618
+            DicomValidation.AutoValidation = false;
+#pragma warning restore 618
         }
 
         [OneTimeTearDown]
@@ -157,7 +162,7 @@ namespace DicomTypeTranslation.Tests
                     break;
 
                 case "JsonDicomConverter":
-                    Assert.Throws<FormatException>(() => VerifyJsonTripleTrip(ds), $"[{convType}] Expected FormatException parsing 2.500000 as an IntegerString");
+                    Assert.Throws<OverflowException>(() => VerifyJsonTripleTrip(ds), $"[{convType}] Expected OverflowException parsing 2.500000 as an IntegerString");
                     break;
 
                 default:
@@ -300,13 +305,8 @@ namespace DicomTypeTranslation.Tests
                         break;
 
                     case "JsonDicomConverter":
-                        if (i == 2 || i == 3)
-                            Assert.Throws<ArgumentException>(() => DicomTypeTranslater.SerializeDatasetToJson(ds, _jsonDicomConverter));
-                        else
-                        {
-                            json = DicomTypeTranslater.SerializeDatasetToJson(ds, _jsonDicomConverter);
-                            Assert.True(json.Equals("{\"00101030\":{\"vr\":\"DS\",\"Value\":[" + expectedValues[i] + "]}}"));
-                        }
+                        json = DicomTypeTranslater.SerializeDatasetToJson(ds, _jsonDicomConverter);
+                        Assert.True(json.Equals("{\"00101030\":{\"vr\":\"DS\",\"Value\":[" + expectedValues[i] + "]}}"));
                         break;
 
                     default:

--- a/DicomTypeTranslation/DicomTypeTranslation.csproj
+++ b/DicomTypeTranslation/DicomTypeTranslation.csproj
@@ -29,7 +29,7 @@
     <None Include="Elevation\TagElevation.cd" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="fo-dicom.NetCore" Version="4.0.6" />
+    <PackageReference Include="fo-dicom.NetCore" Version="4.0.7" />
     <PackageReference Include="HIC.FAnsiSql" Version="1.0.6" />
     <PackageReference Include="MongoDB.Driver" Version="2.11.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/DicomTypeTranslation/HIC.DicomTypeTranslation.nuspec
+++ b/DicomTypeTranslation/HIC.DicomTypeTranslation.nuspec
@@ -13,7 +13,7 @@
     <copyright>Copyright 2019</copyright>
     <tags>Dicom,ETL,SQL</tags>
     <dependencies>
-      <dependency id="fo-dicom.NetCore" version="4.0.6" />
+      <dependency id="fo-dicom.NetCore" version="4.0.7" />
       <dependency id="HIC.FAnsiSql" version="1.0.6" />
       <dependency id="MongoDB.Driver" version="2.11.3" />
       <dependency id="Newtonsoft.Json" version="12.0.3" />


### PR DESCRIPTION
## Proposed Changes

Bumps fo-dicom to v4.0.7. This fixes a bug parsing null-terminated number strings.

## Types of changes

What types of changes does your code introduce? Tick all that apply.

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [x] Reviewed the [contributing](https://github.com/HicServices/DicomTypeTranslation/blob/master/CONTRIBUTING.md) guidelines for this repository
- [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [x] Updated any relevant API documentation
- [x] Created or updated any tests if relevant
- [x] Accurately updated the [CHANGELOG](https://github.com/HicServices/DicomTypeTranslation/blob/master/CHANGELOG.md)
- [x] Listed myself in the [CONTRIBUTORS](https://github.com/HicServices/DicomTypeTranslation/blob/master/CONTRIBUTORS.md) file 🚀
- [x] Requested a review by one of the repository maintainers

## Issues

If relevant, tag any issues that are *expected* to be resolved with this PR. E.g.:

-   Closes https://github.com/fo-dicom/fo-dicom/issues/665

